### PR TITLE
Migrate USB, thermal QTI HAL to AIDL

### DIFF
--- a/generic/vendor/common/file_contexts
+++ b/generic/vendor/common/file_contexts
@@ -120,7 +120,7 @@
 /vendor/bin/ATFWD-daemon        u:object_r:vendor_atfwd_exec:s0
 /vendor/bin/hw/android\.hardware\.vr@1\.0-service.crosshatch      u:object_r:hal_vr_default_exec:s0
 /vendor/bin/hw/android\.hardware\.biometrics\.fingerprint@2\.1-service\.fpc u:object_r:hal_fingerprint_default_exec:s0
-/vendor/bin/hw/android.hardware.thermal@2.0-service.qti      u:object_r:hal_thermal_default_exec:s0
+/vendor/bin/hw/android\.hardware\.thermal-service\.qti     u:object_r:hal_thermal_default_exec:s0
 /vendor/bin/hw/vendor.qti.hardware.limits@1.0-service      u:object_r:vendor_hal_limits_qti_exec:s0
 /vendor/bin/thermal-engine      u:object_r:vendor_thermal-engine_exec:s0
 /vendor/bin/sensors.qti         u:object_r:vendor_sensors_qti_exec:s0

--- a/generic/vendor/common/file_contexts
+++ b/generic/vendor/common/file_contexts
@@ -161,7 +161,6 @@
 /vendor/bin/oemlock_provision   u:object_r:hal_bootctl_default_exec:s0
 /vendor/bin/oemlock-bridge      u:object_r:hal_bootctl_default_exec:s0
 /(vendor|system/vendor)/bin/msm_irqbalance u:object_r:vendor_msm_irqbalanced_exec:s0
-/vendor/bin/hw/android\.hardware\.usb@1\.1-service.crosshatch             u:object_r:hal_usb_default_exec:s0
 /vendor/bin/chre                u:object_r:vendor_chre_exec:s0
 /vendor/bin/time_daemon         u:object_r:vendor_time_daemon_exec:s0
 /vendor/bin/imsrcsd             u:object_r:vendor_hal_rcsservice_exec:s0

--- a/legacy/vendor/common/file_contexts
+++ b/legacy/vendor/common/file_contexts
@@ -747,7 +747,7 @@
 /(vendor|system/vendor)/bin/wifilearner    u:object_r:wifilearnersvc_exec:s0
 
 #Thermal HAL
-/vendor/bin/hw/android.hardware.thermal@2.0-service.qti    u:object_r:hal_thermal_default_exec:s0
+/vendor/bin/hw/android\.hardware\.thermal-service\.qti     u:object_r:hal_thermal_default_exec:s0
 /vendor/bin/hw/vendor.qti.hardware.limits@1.0-service      u:object_r:vendor_hal_limits_qti_exec:s0
 
 # MMC

--- a/legacy/vendor/common/file_contexts
+++ b/legacy/vendor/common/file_contexts
@@ -352,8 +352,8 @@
 /(vendor|system/vendor)/bin/power_off_alarm        u:object_r:power_off_alarm_exec:s0
 /vendor/bin/hw/vendor\.qti\.hardware\.vibrator@1\.[0-2]-service    u:object_r:hal_vibrator_default_exec:s0
 /vendor/bin/hw/vendor\.qti\.hardware\.vibrator\.service    u:object_r:hal_vibrator_default_exec:s0
-/(vendor|system/vendor)/bin/hw/android\.hardware\.usb\@1\.[0-3]-service-qti    u:object_r:hal_usb_qti_exec:s0
-/(vendor|system/vendor)/bin/hw/android\.hardware\.usb\.gadget\@1\.[0-2]-service-qti    u:object_r:hal_usb_qti_exec:s0
+/vendor/bin/hw/android\.hardware\.usb-service\.qti    u:object_r:hal_usb_qti_exec:s0
+/vendor/bin/hw/android\.hardware\.usb\.gadget-service\.qti    u:object_r:hal_usb_qti_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.qti\.hardware\.scve\.panorama@1\.0-service    u:object_r:vendor_scve_exec:s0
 /(vendor|system/vendor)/bin/hw/vendor\.qti\.hardware\.scve\.objecttracker@1\.0-service    u:object_r:vendor_scve_exec:s0
 /(vendor|system/vendor)/bin/hdcp_srm               u:object_r:hdcp_srm_exec:s0

--- a/qva/vendor/common/file_contexts
+++ b/qva/vendor/common/file_contexts
@@ -136,8 +136,8 @@
 /(vendor|system/vendor)/bin/wigighalsvc                                            u:object_r:vendor_wigighalsvc_exec:s0
 /(vendor|system/vendor)/bin/wigignpt                                               u:object_r:vendor_wigignpt_exec:s0
 /(vendor|system/vendor)/bin/sensingdaemon                                          u:object_r:vendor_sensingdaemon_exec:s0
-/vendor/bin/hw/android\.hardware\.usb\@1\.[0-3]-service-qti                        u:object_r:vendor_hal_usb_qti_exec:s0
-/vendor/bin/hw/android\.hardware\.usb\.gadget\@1\.[0-2]-service-qti                u:object_r:vendor_hal_usb_qti_exec:s0
+/vendor/bin/hw/android\.hardware\.usb-service\.qti                                 u:object_r:vendor_hal_usb_qti_exec:s0
+/vendor/bin/hw/android\.hardware\.usb\.gadget-service\.qti                         u:object_r:vendor_hal_usb_qti_exec:s0
 /vendor/bin/vendor\.qti\.qspmhal@1\.0-service                                      u:object_r:vendor_hal_qspmhal_default_exec:s0
 /vendor/bin/qesdk-manager                                                          u:object_r:vendor_hal_qesdhal_default_exec:s0
 /(vendor|system/vendor)/bin/mutualex                                               u:object_r:vendor_mutualex_exec:s0


### PR DESCRIPTION
Follow [topic: lineage-22.0-legacy-um - LineageOS Gerrit](https://review.lineageos.org/q/project:LineageOS/android_device_qcom_sepolicy_vndr+branch:lineage-22.0-legacy-um) , and maybe we should do the same for device side HALs